### PR TITLE
Version 2 of boliv_neighbors...such speedy

### DIFF
--- a/boliv_neighbors_v2.R
+++ b/boliv_neighbors_v2.R
@@ -1,0 +1,51 @@
+### Script to get neighboring pixel info for Bolivia
+# Optimized version by QDR, 19 Feb 2021
+
+### Load libraries
+library(raster)
+
+### Open data
+boliv <- raster("/nfs/agfrontiers-data/Remote Sensing/KS files/classi_bol_dry_2008_102033.tif")
+
+### Define function taking the raster as input.
+# All mapping across cells is internal in the function so the function only needs to be run once.
+# There is no parallelization anymore because the whole thing runs in a few minutes!
+percent_different_neighbors <- function(r) {
+  
+  cells <- 1:ncell(r) # Get the number of cells in the raster.
+  col_index <- colFromCell(r, cells) # Get the column index of each cell in the raster.
+  r_values <- getValues(r) # Get the values of the raster.
+  nc <- ncol(r) # Get the number of columns in the raster.
+  
+  # For each cell, the same adjustment is used to find the index of its neighbors.
+  nbrs <- c(0, -nc-1, -nc, -nc+1, -1, +1, +nc-1, +nc, +nc+1) 
+  
+  ad <- sapply(nbrs, function(x) cells + x) # Add that adjustment value to every cell index.
+  colnames(ad) <- c("center", "NW", "N", "NE", "W", "E", "SW", "S", "SE") # Just FYI to show you which neighbor each column represents.
+  
+  # these three lines deal with edge issues, replacing the appropriate neighbor index values for cells that are on the edge of the raster with NA
+  ad[col_index == 1, c(2, 5, 7)] <- NA
+  ad[col_index == nc, c(4, 6, 9)] <- NA
+  ad[ad<1] <- NA
+  
+  # For each cell, get the values corresponding to the indices of its neighbors.
+  advalues <- t(apply(ad, 1, function(idx) r_values[idx]))
+  
+  # For each of the sets of neighbor values, calculate the percent different from the focal cell and return the result.
+  apply(advalues, 1, function(x) {
+    x <- x[!is.na(x)]
+    sum(x!=x[1])/(length(x)-1)*100
+  })
+  
+}
+
+### Call the function on the boliv raster
+perc_diff_values <- percent_different_neighbors(boliv)
+
+### Make a new raster with the cells
+perc_diff_raster <- setValues(boliv, perc_diff_values)
+
+writeRaster(perc_diff_raster, 
+            filename = "/nfs/agfrontiers-data/Remote Sensing/KS files/bol_perc_diff.tiff",
+            format = "GTiff",
+            overwrite = TRUE)


### PR DESCRIPTION
This is a different version of the boliv_neighbors script using a different method to get the values. It turned out the adjacent() function was also a bit of a bottleneck so I replaced it with a manual version that just adds 9 adjustment values to each cell index to get the 9 neighbor index values. This was inspired by this stackoverflow post https://stackoverflow.com/questions/56771620/get-values-from-adjacent-cells-raster-r where the top answer is written by Robert Hijmans, developer of the raster package (thus why I'm very confident it gives correct results). I verified it works on smaller rasters and also ran the whole thing on the Bolivia raster in probably about 20 minutes. So you should not have any trouble running this on your laptop if you want! (Though of course it can never hurt to use the cluster.)